### PR TITLE
refactor: improve whatsapp initialization

### DIFF
--- a/src/waService.js
+++ b/src/waService.js
@@ -6,39 +6,72 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
-const waClient = new Client({
-  authStrategy: new LocalAuth({ clientId: process.env.APP_SESSION_NAME || 'wa-service' }),
-  puppeteer: {
-    headless: 'new',
-    args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage']
-  }
-});
+let waClient;
 
-waClient.on('qr', qr => {
-  qrcode.generate(qr, { small: true });
-  console.log('[WA] QR code generated, scan please.');
-});
+export async function initWA() {
+  if (waClient) return waClient;
 
-waClient.on('ready', () => {
-  console.log('[WA] Client is ready');
-});
-
-waClient.on('message', async msg => {
-  try {
-    const backend = process.env.BACKEND_URL;
-    if (!backend) return;
-    const payload = { from: msg.from, body: msg.body, timestamp: msg.timestamp };
-    const { data } = await axios.post(`${backend}/wa/incoming`, payload);
-    const replies = data?.replies || [];
-    for (const r of replies) {
-      const text = typeof r === 'string' ? r : r.message;
-      if (text) await waClient.sendMessage(msg.from, text);
+  const client = new Client({
+    authStrategy: new LocalAuth({ clientId: process.env.APP_SESSION_NAME || 'wa-service' }),
+    restartOnAuthFail: true,
+    puppeteer: {
+      headless: true,
+      args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage']
     }
-  } catch (err) {
-    console.error('[WA] Error forwarding message:', err.message);
+  });
+
+  client.on('qr', qr => {
+    qrcode.generate(qr, { small: true });
+    console.log('[WA] QR code generated, scan please.');
+  });
+
+  client.on('authenticated', () => console.log('[WA] Authenticated'));
+
+  client.on('auth_failure', msg => {
+    console.error('[WA] AUTH FAILURE', msg);
+  });
+
+  client.on('ready', () => {
+    console.log('[WA] Client is ready');
+  });
+
+  client.on('disconnected', reason => {
+    console.log('[WA] Disconnected:', reason);
+  });
+
+  client.on('message', async msg => {
+    try {
+      const backend = process.env.BACKEND_URL;
+      if (!backend) return;
+      const payload = { from: msg.from, body: msg.body, timestamp: msg.timestamp };
+      const { data } = await axios.post(`${backend}/wa/incoming`, payload);
+      const replies = data?.replies || [];
+      for (const r of replies) {
+        const text = typeof r === 'string' ? r : r.message;
+        if (text) await client.sendMessage(msg.from, text);
+      }
+    } catch (err) {
+      console.error('[WA] Error forwarding message:', err.message);
+    }
+  });
+
+  await client.initialize();
+  waClient = client;
+
+  process.once('SIGINT', async () => {
+    try {
+      await waClient.destroy();
+    } finally {
+      process.exit(0);
+    }
+  });
+
+  return waClient;
+}
+
+export function getClient() {
+  if (!waClient) {
+    throw new Error('WhatsApp client not initialized. Call initWA() first.');
   }
-});
-
-waClient.initialize();
-
-export { waClient };
+  return waClient;
+}


### PR DESCRIPTION
## Summary
- refactor WhatsApp service to expose explicit `initWA` and `getClient` helpers
- delay server start until WhatsApp client initialization completes
- add lifecycle events and graceful shutdown for WA client

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2c77976248327b93eb48484906af9